### PR TITLE
Bundlerのバージョンダウン

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-20
+  ruby
 
 DEPENDENCIES
   bootsnap (>= 1.4.2)
@@ -227,4 +227,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.4
+   2.1.4


### PR DESCRIPTION
GitHub Actionsのワークフローが失敗したため。